### PR TITLE
Make gp_export_translations_filename filter pass the correct parameter

### DIFF
--- a/gp-bulk-download-translations.php
+++ b/gp-bulk-download-translations.php
@@ -148,7 +148,7 @@ class GP_Bulk_Download_Translations {
 		$filename = sprintf( '%s-%s.'.$format_obj->extension, str_replace( '/', '-', $project->path ), $export_locale );
 
 		// Apply any filters that other plugins may have implemented to the filename.
-		$filename = apply_filters( 'gp_export_translations_filename', $filename, $format_obj, $export_locale, $project, $set );
+		$filename = apply_filters( 'gp_export_translations_filename', $filename, $format_obj, $locale, $project, $set );
 
 		// Get the contents from the formatter.
 		$contents = $format_obj->print_exported_file( $project, $locale, $set, $entries );


### PR DESCRIPTION
The call to the gp_export_translations_filename filter is currently passing the wrong parameter - the third parameter should be a GP_Locale object, not an export locale string. See: https://github.com/GlotPress/GlotPress-WP/blob/317def3bf91c6fa13f69df3e84e3788097bd7e1f/gp-includes/routes/translation.php#L157
