### PR TITLE
Make export_to_file method public

### DIFF
--- a/gp-bulk-download-translations.php
+++ b/gp-bulk-download-translations.php
@@ -80,7 +80,7 @@ class GP_Bulk_Download_Translations {
 			// Loop through all the formats we're exporting
 			foreach( $include_formats as $format ) {
 				// Export the PO file for this translation set.
-				$files[] .= $this->_export_to_file( $format, $temp_dir, $project_obj, $locale, $set );
+				$files[] .= $this->export_to_file( $format, $temp_dir, $project_obj, $locale, $set );
 			}
 		}
 		
@@ -128,7 +128,7 @@ class GP_Bulk_Download_Translations {
 		rmdir( $temp_dir );
 	}
 	
-	private function _export_to_file( $format, $dir, $project, $locale, $set ) {
+	public function export_to_file( $format, $dir, $project, $locale, $set ) {
 		// Get the entries we going to export.
 		$entries = GP::$translation->for_export( $project, $set );
 		


### PR DESCRIPTION
I have some command-line based tools that export all our translations, and am currently moving over to GlotPress.

Rather than re-invent the wheel and keep maintaining our own custom tools, I'd prefer to re-use as much of existing public code - like this - as possible. This change makes export_to_file() public so that it can be called externally - currently, it can only be called via a method which assumes it's running over HTTP, which doesn't suit our use case.
