### PR TITLE
PHP8.1 compatibility fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 1.x
+* Release date: xx
+* PHP 8.1 compatibility with not dynamically creating variables
+
 ## 1.1
 * Release date: June 20, 2016
 * Renamed main plugin file.

--- a/gp-bulk-download-translations.php
+++ b/gp-bulk-download-translations.php
@@ -13,6 +13,10 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 class GP_Bulk_Download_Translations {
 	public $id = 'gp-bulk-download-translations';
+	public $api;
+	public $last_method_called;
+	public $class_name;
+	public $request_running;
 
 	public function __construct() {
 		// We need the Zip class to do the bulk export, if it doesn't exist, don't bother enabling the plugin.


### PR DESCRIPTION
No more dynamic variable creation

I needed to declare a number of variables that were being dynamically created.

Thanks for considering this PR.